### PR TITLE
Errata 1.1

### DIFF
--- a/almacenamiento.md
+++ b/almacenamiento.md
@@ -16,7 +16,7 @@ Las claves se conformarán por cadenas de hasta 40 caracteres.
 
 ## Valor
 
-El valor almacenado para cada key será de tamaño variable, dando lugar a la posibilidad de que un valor ocupe más de una sola entrada en la Instancia de Re Distinto. Otros casos posibles que surgen por la naturaleza variable del valor son aquellos casos en los que el valor tiene menor tamaño que una Entrada; en este caso, se produce fragmentación interna[^13] en esta Entrada.
+El valor almacenado para cada key será de tamaño variable, dando lugar a la posibilidad de que un valor ocupe más de una sola entrada en la Instancia de Re Distinto. Otros casos posibles que surgen por la naturaleza variable del valor son aquellos casos en los que el valor tiene menor tamaño que una Entrada; en este caso, se produce fragmentación interna(^13) en esta Entrada.
 
 ## Valor Atómico
 
@@ -36,7 +36,7 @@ El algoritmo Circular consiste en tener un puntero sobre las entradas de almacen
 
 ### Least Recently Used
 
-El algoritmo LRU se basa en llevar registro de hace cuánto fue referenciada cada entrada. Llegado el momento de reemplazar una entrada, se selecciona aquella entrada que ha sido referenciada hace mayor tiempo[^14].
+El algoritmo LRU se basa en llevar registro de hace cuánto fue referenciada cada entrada. Llegado el momento de reemplazar una entrada, se selecciona aquella entrada que ha sido referenciada hace mayor tiempo(^14).
 
 ![Reemplazo LRU](assets/reemplazo-lru.png)
 
@@ -48,7 +48,7 @@ Por último, el algoritmo BSU lleva registro del tamaño dentro de la entrada at
 
 ## Compactación
 
-Dada la naturaleza del almacenamiento en Re Distinto, existe la posibilidad de que se produzca fragmentación externa[^15], impidiendo almacenar más datos en casos en los que en realidad sí existe espacio para guardarlos. Ante éstas situaciones, Re Distinto activará automáticamente el proceso de Compactación ante dicho caso (el cual también puede ser ejecutado de forma manual con una operación). Este proceso se ejecuta internamente en cada una de las Instancias de forma simultánea; es decir, que cuando llegue el momento de realizar una Compactación, todas las Instancias realizarán dicho proceso.
+Dada la naturaleza del almacenamiento en Re Distinto, existe la posibilidad de que se produzca fragmentación externa(^15), impidiendo almacenar más datos en casos en los que en realidad sí existe espacio para guardarlos. Ante éstas situaciones, Re Distinto activará automáticamente el proceso de Compactación ante dicho caso (el cual también puede ser ejecutado de forma manual con una operación). Este proceso se ejecuta internamente en cada una de las Instancias de forma simultánea; es decir, que cuando llegue el momento de realizar una Compactación, todas las Instancias realizarán dicho proceso.
 
 El proceso de Compactación consiste en el reordenamiento de los datos almacenados en las Entradas, de forma de eliminar los huecos de espacio libre que se generan debido a la fragmentación externa.
 
@@ -59,6 +59,8 @@ Además de realizar el reordenamiento físico de los datos, es de suma importanc
 Mientras está en ejecución el proceso de Compactación y Dump, no se permitirá ejecutar operaciones en el Sistema de Re Distinto y quedarán en espera a que el proceso se complete correctamente.
 
 ---
-[^13]: Se profundizará en la cursada.
-[^14]: Para simplificar el manejo de referencias sólo se llevará cuenta de hace cuantas operaciones fue referenciada cada entrada, almacenando el número de ultima referencia y reemplazando el menor.
-[^15]: Se profundizará en la cursada.
+^13: Se profundizará en la cursada.
+
+^14: Para simplificar el manejo de referencias sólo se llevará cuenta de hace cuantas operaciones fue referenciada cada entrada, almacenando el número de ultima referencia y reemplazando el menor.
+
+^15: Se profundizará en la cursada.

--- a/anexo-i---lenguaje-operaciones.md
+++ b/anexo-i---lenguaje-operaciones.md
@@ -6,14 +6,14 @@
 
 ## Blocking
 
-En el sistema de Re Distinto, el bloqueo se realiza sobre las claves que son solicitadas a lo largo de la ejecución de un script. Específicamente, los bloqueos se aplicarán a medida que se trabaja con una clave[^16] y solo se liberaran dichas claves cuando se realice una operación `STORE` o cuando termine la ejecución del script que bloqueo la clave.
+En el sistema de Re Distinto, el bloqueo se realiza sobre las claves que son solicitadas a lo largo de la ejecución de un script. Específicamente, los bloqueos se aplicarán a medida que se trabaja con una clave(^16) y solo se liberaran dichas claves cuando se realice una operación `STORE` o cuando termine la ejecución del script que bloqueo la clave.
 
 | Script 1             | Script 2             |
 |----------------------|----------------------|
 | `GET materias:K3001` | `GET materias:K2001` |
 | `GET materias:K2001` | `GET materias:K3001` |
 
-En este caso, el script 1 bloquea la clave materias:K3001 en su primer operación, impidiendo que el script 2 pueda utilizar dicha clave hasta que el script 1 la libere. De la misma manera, el script 2 hace lo mismo con la clave materias:K2001 en su primera operación. Cuando estos scripts llegan a la segunda operación, se da una particularidad y es que ambos están a la espera de que el otro script libere la clave que están usando. Este fenómeno se conoce como deadlock[^17].
+En este caso, el script 1 bloquea la clave materias:K3001 en su primer operación, impidiendo que el script 2 pueda utilizar dicha clave hasta que el script 1 la libere. De la misma manera, el script 2 hace lo mismo con la clave materias:K2001 en su primera operación. Cuando estos scripts llegan a la segunda operación, se da una particularidad y es que ambos están a la espera de que el otro script libere la clave que están usando. Este fenómeno se conoce como deadlock(^17).
 
 ## Ejemplo de Script
 
@@ -44,5 +44,6 @@ En caso de que ocurra un error en la comunicación con algún proceso, se deber�
 Si la clave que se desea acceder no existe en el sistema, el ESI qué ejecutó ese pedido será abortado, se deberá generar un error informando al Usuario de dicho problema.
 
 ---
-[^16]: Solo la operación GET bloquea una clave.
-[^17]: Se verá durante la cursada con mayor detalle.
+^16: Solo la operación GET bloquea una clave.
+
+^17: Se verá durante la cursada con mayor detalle.

--- a/coordinador.md
+++ b/coordinador.md
@@ -8,7 +8,7 @@ Para poder simular el paso del tiempo en la ejecución, cada vez que un ESI le p
 
 ## Inicialización
 
-El Coordinador deberá ser el primero en iniciarse, y le proveerá a las distintas instancias la configuración de tamaños de la cantidad y el tamaño de las entradas. En primera instancia, leerá su archivo de configuración e inicializará todas las estructuras administrativas que requerirá para la gestión del sistema. Una vez realizado el proceso de inicialización, quedará a la espera de solicitudes de conexión ya sea de Instancias de Re Distinto o de procesos ESI[^5]. Por cada una de las conexiones que sean aceptadas, el Coordinador lanzará un Hilo encargado de atender la conexión.
+El Coordinador deberá ser el primero en iniciarse, y le proveerá a las distintas instancias la configuración de tamaños de la cantidad y el tamaño de las entradas. En primera instancia, leerá su archivo de configuración e inicializará todas las estructuras administrativas que requerirá para la gestión del sistema. Una vez realizado el proceso de inicialización, quedará a la espera de solicitudes de conexión ya sea de Instancias de Re Distinto o de procesos ESI(^5). Por cada una de las conexiones que sean aceptadas, el Coordinador lanzará un Hilo encargado de atender la conexión.
 
 ## Ejecución
 
@@ -29,12 +29,12 @@ El Coordinador recibirá desde los procesos ESI solicitudes. Además, por cada s
 ![Interacción con ESI e Instancia](assets/interaccion-esi-instancia.png)
 
 1. El Coordinador recibe una solicitud proveniente de un proceso ESI.
-2. El Coordinador procesa la solicitud en su algoritmo de distribución con el fin de determinar la Instancia a la que se le asignará la solicitud[^6].
+2. El Coordinador procesa la solicitud en su algoritmo de distribución con el fin de determinar la Instancia a la que se le asignará la solicitud(^6).
 3. Se elige la Instancia asociada y se le envía la solicitud.
 4. La instancia retorna al Coordinador
 5. El Coordinador logea la respuesta y envía al ESI
 
-En el caso que el coordinador decida en el paso 2 que la operación no puede ser ejecutada porque la instancia no existe más en el sistema, o porque el recurso al que intenta acceder se encuentra tomado[^7], le avisará al Planificador. El Planificador encolará el ESI en cuestión en una cola de bloqueados; en ambos casos haciendo referencia al recurso que se intentó bloquear.
+En el caso que el coordinador decida en el paso 2 que la operación no puede ser ejecutada porque la instancia no existe más en el sistema, o porque el recurso al que intenta acceder se encuentra tomado(^7), le avisará al Planificador. El Planificador encolará el ESI en cuestión en una cola de bloqueados; en ambos casos haciendo referencia al recurso que se intentó bloquear.
 
 Es importante destacar que la operación GET no genera ningún registro dentro de la instancia, si no que solo modifica el estado de bloqueos y desbloqueos en el planificador. Es el SET el encargado de alterar el valor.
 
@@ -42,7 +42,7 @@ Es importante destacar que la operación GET no genera ningún registro dentro d
 
 El sistema de Re Distinto aplica bloqueos sobre claves utilizadas. Es decir, a medida que un ESI solicita una operación de GET sobre una clave específica, esta pasa a estar “tomada” y no puede ser tomada (GET) por ningún ESI hasta que se libere (STORE).
 
-Para lograr este comportamiento, el **Planificador** lleva un registro de qué claves fueron bloqueadas por cada `ESI` en particular. Las cuales deberá liberar en cuanto reciba una operación `STORE` con dicha clave por parte de la `ESI` bloqueadora[^8]. Esta liberación será de manera **FIFO**; el primer ESI que se encontraba bloqueado esperando esta clave será liberada _(Esto no quiere decir que será inmediatamente tomado por este ESI; sino que estará disponible para ser planificado; y deberá re ejecutar la operación de `GET` al ser ejecutado)_.
+Para lograr este comportamiento, el **Planificador** lleva un registro de qué claves fueron bloqueadas por cada `ESI` en particular. Las cuales deberá liberar en cuanto reciba una operación `STORE` con dicha clave por parte de la `ESI` bloqueadora(^8). Esta liberación será de manera **FIFO**; el primer ESI que se encontraba bloqueado esperando esta clave será liberada _(Esto no quiere decir que será inmediatamente tomado por este ESI; sino que estará disponible para ser planificado; y deberá re ejecutar la operación de `GET` al ser ejecutado)_.
 
 Cabe aclarar que la finalización de un ESI libera los recursos que este tenía tomados.
 
@@ -76,7 +76,11 @@ Cabe aclarar que la finalización de un ESI libera los recursos que este tenía 
 5. El Planificador responde que esta clave se encuentra tomada, y toma nota que el ESI2 se encuentra bloqueado esperándola.
 
 ---
-[^5]: Para poder distinguir qué proceso se está conectado, intercambiará mensajes con el proceso (este procedimiento se conoce como handshaking).
-[^6]: Recordar que en el caso de ser un GET. No se necesita acceder a ninguna instancia.
-[^7]: Esta información la obtiene al interactuar con el planificador para actualizar el estado en este último.
-[^8]: Es importante tener en cuenta esto a la hora de implementar el comando "deadlock" de la consola del planificador
+
+^5: Para poder distinguir qué proceso se está conectado, intercambiará mensajes con el proceso (este procedimiento se conoce como handshaking).
+
+^6: Recordar que en el caso de ser un GET. No se necesita acceder a ninguna instancia.
+
+^7: Esta información la obtiene al interactuar con el planificador para actualizar el estado en este último.
+
+^8: Es importante tener en cuenta esto a la hora de implementar el comando "deadlock" de la consola del planificador

--- a/distribucion.md
+++ b/distribucion.md
@@ -4,7 +4,7 @@ Para generar alta disponibilidad del sistema, el Coordinador de Re Distinto se e
 
 ## Algoritmos de Distribución
 
-### Equitative Load[^11]
+### Equitative Load(^11)
 
 El algoritmo Equitative Load es el más básico de todos pero, a su vez, es el menos ambiguo de todos. Consiste en despachar una solicitud a una Instancia distinta cada vez. De esta forma, la ejecución de solicitudes se distribuye de forma equitativa entre todas las Instancias.
 
@@ -16,7 +16,7 @@ El algoritmo LSU se basa en distribuir la ejecución de solicitudes de almacenam
 
 Por último, el algoritmo Key Explicit, define la Instancia que ejecutará cada solicitud de almacenamiento en la Clave misma. Cuando este algoritmo está en uso, se tomará el primer carácter de la clave en minúscula como indicador de Instancia a la que le corresponde la ejecución de la solicitud.
 
-_Consideremos un instante donde existan 4 instancias, la primera instancia será la encargada de almacenar claves que comienzan con las letras "a" a la "g". La segunda instancia de la "h" a la "m". La tercera instancia de la letra "n" hasta la "t", y por último la cuarta instancia de la letra "u" a la "z"[^12]. De agregarse nuevas instancias, las claves previamente almacenadas no se moverán de lugar; pero nuevas claves usarán el nuevo número de instancias para calcular la distribución._
+_Consideremos un instante donde existan 4 instancias, la primera instancia será la encargada de almacenar claves que comienzan con las letras "a" a la "g". La segunda instancia de la "h" a la "m". La tercera instancia de la letra "n" hasta la "t", y por último la cuarta instancia de la letra "u" a la "z"(^12). De agregarse nuevas instancias, las claves previamente almacenadas no se moverán de lugar; pero nuevas claves usarán el nuevo número de instancias para calcular la distribución._
 
 ## Desconexión
 
@@ -27,5 +27,6 @@ Durante la ejecución del Sistema, existe la posibilidad de que una o más Insta
 Así como las Instancias pueden dejar de estar disponibles, también pueden reincorporarse al Sistema y nuevas Instancias también pueden ser agregadas al mismo.
 
 ---
-[^11]: Llegado el caso de que un algoritmo produzca un empate, se utilizará el algoritmo Equitative Load, el cual será el desempatador para todos los algoritmos de distribución.
-[^12]: La letra "a" se codifica como el carácter 97 y la "z" como el 122, por lo que habrá 25 letras a ser divididas en 4 instancias, cada una con 7 letras y la última con solo 4. Cada instancia redondeará para arriba la cantidad de claves a ser usadas; y la última posiblemente tenga menos rango que aceptaría
+^11: Llegado el caso de que un algoritmo produzca un empate, se utilizará el algoritmo Equitative Load, el cual será el desempatador para todos los algoritmos de distribución.
+
+^12: La letra "a" se codifica como el carácter 97 y la "z" como el 122, por lo que habrá 25 letras a ser divididas en 4 instancias, cada una con 7 letras y la última con solo 4. Cada instancia redondeará para arriba la cantidad de claves a ser usadas; y la última posiblemente tenga menos rango que aceptaría

--- a/ejecutor-sentencias-interactivas.md
+++ b/ejecutor-sentencias-interactivas.md
@@ -1,6 +1,6 @@
 # Ejecutor Sentencias Interactivas (ESI)
 
-Los Procesos ESI son el punto de entrada al Sistema. Estos correrán un script con instrucciones a ser ejecutadas[^1]. Sú única función es la de interpretar de a una las líneas de un programa _(que se le pasará como argumento)_ a medida que el Planificador se lo indique. Para resolver las distintas sentencias del programa a ser interpretado; deberá colaborar con el coordinador para bloquear/liberar recursos o datos.
+Los Procesos ESI son el punto de entrada al Sistema. Estos correrán un script con instrucciones a ser ejecutadas(^1). Sú única función es la de interpretar de a una las líneas de un programa _(que se le pasará como argumento)_ a medida que el Planificador se lo indique. Para resolver las distintas sentencias del programa a ser interpretado; deberá colaborar con el coordinador para bloquear/liberar recursos o datos.
 
 ## Conexión
 
@@ -28,4 +28,4 @@ Por cada una de las sentencias interpretadas, es necesario realizar un proceso d
 | Puerto de Conexión al Planificador | [numérico] | `8001`        |
 
 ---
-[^1]: Para conocer en profundidad las instrucciones ver el [Anexo I](anexo-i---lenguaje-operaciones.md).
+^1: Para conocer en profundidad las instrucciones ver el [Anexo I](anexo-i---lenguaje-operaciones.md).

--- a/instancia.md
+++ b/instancia.md
@@ -1,11 +1,11 @@
 # Instancia
 
-Las Instancias de Re Distinto son los procesos encargados del almacenamiento de los datos. Cada Instancia secciona su espacio de almacenamiento en lo que se denominan Entradas y al iniciar la conexión con el coordinador, se definirá el tamaño de las mismas así como la cantidad total disponible dentro de la Instancia. En la sección de almacenamiento se entrará más en detalle respecto a las Entradas.[^1]
+Las Instancias de Re Distinto son los procesos encargados del almacenamiento de los datos. Cada Instancia secciona su espacio de almacenamiento en lo que se denominan Entradas y al iniciar la conexión con el coordinador, se definirá el tamaño de las mismas así como la cantidad total disponible dentro de la Instancia. En la sección de almacenamiento se entrará más en detalle respecto a las Entradas.(^9)
 
 ## Tabla de Entradas
 
 La Tabla de Entradas es una estructura administrativa de la Instancia de Re Distinto que permite gestionar el almacenamiento y facilitar el acceso a los valores almacenados.
-Para esto, en cada elemento de la tabla se almacenará una clave, el número de entrada asociada y el tamaño del valor almacenado.[^2]
+Para esto, en cada elemento de la tabla se almacenará una clave, el número de entrada asociada y el tamaño del valor almacenado.(^9)
 
 ## Interacción con Coordinador
 
@@ -30,5 +30,6 @@ Para esto, en cada elemento de la tabla se almacenará una clave, el número de 
 | Intervalo de dump (en segundos)    | [numérico]         | `10`                        |
 
 ---
-[^9]: Para más información, investigar sobre el comando [malloc()](https://linux.die.net/man/3/malloc).
-[^10]: Dada la naturaleza de almacenamiento contiguo de los valores, en caso de que el tamaño del valor exceda el tamaño de la entrada, éste continuará en la siguiente entrada.
+^9: Para más información, investigar sobre el comando [malloc()](https://linux.die.net/man/3/malloc).
+
+^10: Dada la naturaleza de almacenamiento contiguo de los valores, en caso de que el tamaño del valor exceda el tamaño de la entrada, éste continuará en la siguiente entrada.

--- a/planificador.md
+++ b/planificador.md
@@ -33,12 +33,12 @@ La estimación inicial de todos los ESI será la misma, y deberá poder ser modi
 
 Mediante una consola, el planificador deberá facilitar al usuario las siguientes operaciones:
 
-* Pausar/Continuar planificación[^2]: El Planificador no le dará nuevas órdenes de ejecución a ningún ESI mientras se encuentre pausado.
-* bloquear <clave> <ID>: Se bloqueará el proceso ESI hasta ser desbloqueado _(ver más adelante)_, especificado por dicho <ID>[^3] en la cola del recurso <clave>. _Vale recordar que cada línea del script a ejecutar es atómica, y no podrá ser interrumpida; si no que se bloqueará en la próxima oportunidad posible. Solo se podrán bloquear de esta manera ESIs que estén en el estado de listo o ejecutando._
-* desbloquear <clave>: Se desbloqueara el primer proceso ESI bloquedo por la <clave> especificada. Solo se bloqueará ESIs que fueron bloqueados con la consola. _Si un ESI está bloqueado esperando un recurso, no podrá ser desbloqueado de esta forma._
-* listar <recurso>: Lista los procesos encolados esperando al recurso.
-* kill <ID>: finaliza el proceso. Recordando la atomicidad mencionada en “bloquear”.
-* status <clave>: Debido a que para la correcta coordinación de las sentencias de acuerdo a los algoritmos de distribución[^4] se requiere de cierta información sobre las instancias del sistema.
+* Pausar/Continuar planificación(^2): El Planificador no le dará nuevas órdenes de ejecución a ningún ESI mientras se encuentre pausado.
+* bloquear _clave ID_: Se bloqueará el proceso ESI hasta ser desbloqueado _(ver más adelante)_, especificado por dicho _ID_(^3) en la cola del recurso _clave_. _Vale recordar que cada línea del script a ejecutar es atómica, y no podrá ser interrumpida; si no que se bloqueará en la próxima oportunidad posible. Solo se podrán bloquear de esta manera ESIs que estén en el estado de listo o ejecutando._
+* desbloquear _clave_: Se desbloqueara el primer proceso ESI bloquedo por la _clave_ especificada. Solo se bloqueará ESIs que fueron bloqueados con la consola. _Si un ESI está bloqueado esperando un recurso, no podrá ser desbloqueado de esta forma._
+* listar _recurso_: Lista los procesos encolados esperando al recurso.
+* kill _ID_: finaliza el proceso. Recordando la atomicidad mencionada en “bloquear”.
+* status _clave_: Debido a que para la correcta coordinación de las sentencias de acuerdo a los algoritmos de distribución(^4) se requiere de cierta información sobre las instancias del sistema.
 * deadlock: Esta consola también permitirá analizar los deadlocks que existan en el sistema y a que ESI están asociados. Pudiendo resolverlos manualmente con la sentencia de kill previamente descrita.
 
 ## Configuración
@@ -54,6 +54,8 @@ Mediante una consola, el planificador deberá facilitar al usuario las siguiente
 | Claves inicialmente bloqueadas    | [Lista de claves]            | `materias:K3002, materias:K3001` |
 
 ---
-[^2]: Esto se puede lograr ejecutando una sycall bloqueante que espere la entrada de un humano.
-[^3]: El Planificador empezará con una serie de claves bloqueadas de esta manera.
-[^4]: Estos algoritmos se detallarán más adelante.
+^2: Esto se puede lograr ejecutando una sycall bloqueante que espere la entrada de un humano.
+
+^3: El Planificador empezará con una serie de claves bloqueadas de esta manera.
+
+^4: Estos algoritmos se detallarán más adelante.


### PR DESCRIPTION
Fixes de estilos para que Gitbook lo muestre bien.

Las footnotes no están soportadas por la nueva versión de gitbook, así que no quedan linkeadas, pero al menos quedan visibles.